### PR TITLE
Documentation: correct project domain from veloxdb.com to veloxdb.dev

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -176,4 +176,4 @@ Feature request issues should describe the use case and why it benefits the proj
 
 ---
 
-Questions? Open a [discussion](https://github.com/abeni16/veloxdb/discussions) or reach out via the [website](https://veloxdb.com).
+Questions? Open a [discussion](https://github.com/abeni16/veloxdb/discussions) or reach out via the [website](https://veloxdb.dev).

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 </p>
 
 <p align="center">
-  <a href="https://veloxdb.com"><strong>Official Website</strong></a> ·
+  <a href="https://veloxdb.dev"><strong>Official Website</strong></a> ·
   <a href="#features">Features</a> ·
   <a href="#installation">Installation</a> ·
   <a href="#development">Development</a> ·
@@ -27,7 +27,7 @@
 
 **VeloxDB** is a **fast, memory-efficient, developer-focused** desktop client for PostgreSQL. Connect directly to your databases — no cloud, no middleware, no telemetry. Built with performance and productivity at its core.
 
-Watch the demo: **[veloxdb.com](https://veloxdb.com)**
+Watch the demo: **[veloxdb.dev](https://veloxdb.dev)**
 
 ---
 


### PR DESCRIPTION
Nice project abeni16 - I was looking for something like this a few days ago. 

Noticed a minor documentation thing when trying to reach the demo. Looks like the domain has a TLD of "com" rather than "dev" in a few spots. Opened #13, and if you're open for a PR, here it is

Pranav