### PR TITLE
fix: wire maxQueryRows settings to backend so it actually takes effect

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -300,6 +300,8 @@ pub async fn run_query(
         return Err("Enter a SQL statement before running the query.".to_string());
     }
 
+    let max_query_rows = input.max_rows.unwrap_or(MAX_QUERY_ROWS);
+
     with_pool_client_retry(&app, &state, &connection_id, sql, |client, sql| async move {
         let started_at = Instant::now();
         let messages = client
@@ -333,7 +335,7 @@ pub async fn run_query(
                             .collect();
                     }
 
-                    if rows.len() >= MAX_QUERY_ROWS {
+                    if rows.len() >= max_query_rows {
                         continue;
                     }
 
@@ -355,7 +357,7 @@ pub async fn run_query(
             row_count: rows.len(),
             rows,
             execution_ms: started_at.elapsed().as_millis(),
-            truncated: total_rows > MAX_QUERY_ROWS,
+            truncated: total_rows > max_query_rows,
             command_tag,
         })
     })

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -69,7 +69,6 @@ pub fn run() {
       get_query_editor_metadata,
       save_base64_png,
       save_text_file,
-      save_text_file,
       lint_sql
     ])
     .run(tauri::generate_context!())

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -121,6 +121,8 @@ pub struct ConnectionSummary {
 pub struct QueryRequest {
     pub connection_id: Option<String>,
     pub sql: String,
+    /// Maximum rows to return for this query. When omitted, the default (`MAX_QUERY_ROWS`) is used.
+    pub max_rows: Option<usize>,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -43,6 +43,8 @@ export type ConnectionSummary = {
 export type QueryRequest = {
   connectionId?: string
   sql: string
+  /** Maximum rows to return. Matches the user's Settings > Results > Max rows preference. */
+  maxRows?: number
 }
 
 export type LintSqlRequest = {

--- a/src/features/queries/queries.test.ts
+++ b/src/features/queries/queries.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+
+import { useSettings } from '@/lib/settings'
+
+describe('maxQueryRows wiring', () => {
+  it('settings default matches the backend MAX_QUERY_ROWS fallback', () => {
+    // When maxRows is omitted from QueryRequest, the Rust backend
+    // falls back to MAX_QUERY_ROWS = 1000. The Zustand settings default
+    // must stay in sync so the UI-preferred value is honoured.
+    expect(useSettings.getState().maxQueryRows).toBe(1000)
+  })
+
+  it('settings store allows custom maxQueryRows values', () => {
+    const prev = useSettings.getState().maxQueryRows
+    useSettings.setState({ maxQueryRows: 5000 })
+    expect(useSettings.getState().maxQueryRows).toBe(5000)
+    // Restore
+    useSettings.setState({ maxQueryRows: prev })
+  })
+})

--- a/src/features/queries/queries.ts
+++ b/src/features/queries/queries.ts
@@ -18,6 +18,7 @@ import {
 } from "@/features/queries/result-edits";
 import { shouldRetryTransientDbInvoke } from "@/lib/transient-invoke-retry";
 import { notifyError } from "@/lib/error-notifier";
+import { useSettings } from "@/lib/settings";
 
 /** UI-only fields for correlating mutation results with a query tab. Stripped before IPC. */
 export type RunQueryTabVariables = QueryRequest & {
@@ -36,10 +37,12 @@ type UseRunQueryMutationOptions = {
 };
 
 export function useRunQueryMutation(options: UseRunQueryMutationOptions = {}) {
+	const maxQueryRows = useSettings((s) => s.maxQueryRows);
+
 	return useMutation({
 		retry: shouldRetryTransientDbInvoke,
 		mutationFn: ({ connectionId, sql }: RunQueryTabVariables) =>
-			veloxDbRepository.runQuery({ connectionId, sql }),
+			veloxDbRepository.runQuery({ connectionId, sql, maxRows: maxQueryRows }),
 		onSuccess: (result, variables) => {
 			options.onSuccess?.(result, variables);
 		},


### PR DESCRIPTION
## Problem

The Settings > Results > Max rows selector (500 / 1,000 / 5,000 / 10,000) was backed by `maxQueryRows` in the Zustand settings store, but this value was **never sent to the Rust backend**. The `run_query` command always used the hardcoded `MAX_QUERY_ROWS = 1000`. Changing the setting in the UI had zero effect — dead UI.

## Fix

Wires the setting through the full IPC stack:

| Layer | File | Change |
|-------|------|--------|
| Rust model | `src-tauri/src/models.rs` | `max_rows: Option<usize>` on `QueryRequest` |
| Rust command | `src-tauri/src/commands.rs` | Uses `input.max_rows.unwrap_or(MAX_QUERY_ROWS)` |
| Rust cleanup | `src-tauri/src/lib.rs` | Removed duplicate `save_text_file` registration |
| TS types | `src/data/types.ts` | `maxRows?: number` on `QueryRequest` |
| TS queries | `src/features/queries/queries.ts` | `useRunQueryMutation` reads setting from Zustand |
| TS test | `src/features/queries/queries.test.ts` | Guards settings default in sync with backend |

## Backward Compatibility

`max_rows` is `Option<usize>` — when absent (all existing DDL, EXPLAIN, and row-edit callers), the default `MAX_QUERY_ROWS = 1000` is used. No breaking changes.

## Verification

- `pnpm test` — 11/11 pass
- `pnpm lint` — 0 new errors (44 pre-existing on main)