### PR TITLE
feat: add notification level settings

### DIFF
--- a/src/features/commands/components/SettingsDialog.tsx
+++ b/src/features/commands/components/SettingsDialog.tsx
@@ -9,6 +9,7 @@ import {
   DatabaseIcon,
   InfoIcon,
   ArrowSquareOutIcon,
+  BellIcon,
 } from '@phosphor-icons/react'
 import { useCallback, useEffect, useState } from 'react'
 
@@ -27,6 +28,7 @@ const tabs = [
   { id: 'editor', label: 'Editor', Icon: CodeIcon },
   { id: 'results', label: 'Results', Icon: TableIcon },
   { id: 'connections', label: 'Connections', Icon: PlugIcon },
+  { id: 'notifications', label: 'Notifications', Icon: BellIcon },
   { id: 'data', label: 'Data', Icon: DatabaseIcon },
   { id: 'about', label: 'About', Icon: InfoIcon },
 ]
@@ -164,6 +166,21 @@ export function SettingsDialog({ open, onOpenChange }: { open: boolean; onOpenCh
               <Field label="Health ping" desc="How often to check connection health.">
                 <Select value={String(settings.pingIntervalSec)} onChange={(v) => useSettings.setState({ pingIntervalSec: Number(v) })}
                   opts={[{ v: '0', l: 'Off' }, { v: '15', l: '15s' }, { v: '30', l: '30s' }, { v: '60', l: '1 min' }, { v: '120', l: '2 min' }]} />
+              </Field>
+            </Section>}
+
+            {tab === 'notifications' && <Section title="Notifications">
+              <Field label="Success toasts" desc="Show success confirmation toasts.">
+                <Toggle
+                  value={settings.toastLevels.success}
+                  onChange={(v) => useSettings.setState({ toastLevels: { ...settings.toastLevels, success: v } })}
+                />
+              </Field>
+              <Field label="Error toasts" desc="Show error toasts when operations fail.">
+                <Toggle
+                  value={settings.toastLevels.error}
+                  onChange={(v) => useSettings.setState({ toastLevels: { ...settings.toastLevels, error: v } })}
+                />
               </Field>
             </Section>}
 

--- a/src/lib/error-notifier.ts
+++ b/src/lib/error-notifier.ts
@@ -5,6 +5,7 @@ import {
 	toUserMessage,
 	type NormalizeErrorOptions,
 } from "@/lib/app-error";
+import { useSettings } from "@/lib/settings";
 
 const recent = new Map<string, number>();
 const DEDUP_MS = 1200;
@@ -39,6 +40,10 @@ export function notifyError(
 	error: unknown,
 	options: NotifyErrorOptions = {},
 ): void {
+	if (!useSettings.getState().toastLevels.error) {
+		return;
+	}
+
 	const normalized = normalizeError(error, options);
 	const title =
 		options.title ?? toastTitleForCategory(normalized.category);
@@ -76,6 +81,10 @@ export function notifySuccess(
 	title: string,
 	description?: string,
 ): void {
+	if (!useSettings.getState().toastLevels.success) {
+		return;
+	}
+
 	try {
 		toast({
 			variant: "success",

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -5,6 +5,9 @@ export type AppTheme = 'system' | 'light' | 'dark'
 export type FontSize = 'sm' | 'md' | 'lg'
 export type NullDisplay = 'null' | 'NULL' | 'dash' | 'empty'
 
+export type ToastLevel = 'success' | 'error'
+export type ToastLevels = Record<ToastLevel, boolean>
+
 export type AppSettings = {
   theme: AppTheme
   fontSize: FontSize
@@ -17,6 +20,7 @@ export type AppSettings = {
   clickToCopy: boolean
   autoReconnect: boolean
   pingIntervalSec: number
+  toastLevels: ToastLevels
 }
 
 const defaults: AppSettings = {
@@ -31,6 +35,7 @@ const defaults: AppSettings = {
   clickToCopy: true,
   autoReconnect: true,
   pingIntervalSec: 30,
+  toastLevels: { success: true, error: true },
 }
 
 export const useSettings = create<AppSettings>()(


### PR DESCRIPTION
## Summary
I added a new settings section "Notifications". Also add enable/disable toggles for every found level of notifications, so users can customize what type of notifications they see.

## Motivation
I really enjoy using the app from the first touch, but I don't want to see success notifications every time I open or execute query. The reason why is I can already see if query was executed successfully and also can see the time taken, so I think it would be better to add customizable settings for displaying different levels of notifications.

## Changes
- New `toastLevels: { success, error }` field in `AppSettings` (defaults to both `true` — preserves current behavior)
- `notifySuccess` / `notifyError` early return when the corresponding level is disabled
- New "Notifications" tab in `SettingsDialog` with two toggles

## Testing
- `pnpm test` — 23/23 pass
- `pnpm lint` — clean for touched files
- Manual: toggled off Success in Settings → "Query executed" toast no longer appears; toggled back on → reappears. Same for Error toasts via a deliberately broken query.
