### PR TITLE
feat: add rename connection function

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -470,6 +470,16 @@ pub async fn disconnect_db(
     Ok(())
 }
 
+/// Renames a saved connection without affecting the active pool or SSH tunnel.
+#[tauri::command]
+pub async fn rename_connection(
+    app: AppHandle,
+    connection_id: String,
+    new_name: String,
+) -> Result<crate::models::ConnectionSummary, String> {
+    crate::db::rename_connection_in_store(&app, &connection_id, &new_name)
+}
+
 #[tauri::command]
 pub async fn delete_connection(
     app: AppHandle,

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -550,6 +550,19 @@ pub fn persist_connection_with_password(
     Ok(())
 }
 
+/// Renames a persisted connection and returns the updated summary.
+pub fn rename_connection_in_store(
+    app: &AppHandle,
+    connection_id: &str,
+    new_name: &str,
+) -> Result<ConnectionSummary, String> {
+    let mut stored = load_connection(app, connection_id)?
+        .ok_or_else(|| format!("Connection {} not found.", connection_id))?;
+    stored.name = new_name.to_string();
+    persist_connection(app, &stored)?;
+    Ok(stored.summary())
+}
+
 pub fn delete_connection_from_store(app: &AppHandle, connection_id: &str) -> Result<(), String> {
     let store = app
         .store(CONNECTION_STORE_PATH)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6,7 +6,7 @@ mod models;
 mod ssh_tunnel;
 
 use commands::{
-  apply_table_properties, connect_db, delete_connection, disconnect_db, execute_ddl_statement,
+  apply_table_properties, connect_db, delete_connection, disconnect_db, execute_ddl_statement, rename_connection,
   execute_ddl_transaction, export_diagram_png, export_results_csv_command,
   export_results_json_command, get_foreign_keys, get_query_editor_metadata, get_schema,
   get_table_indexes, get_table_properties, get_tables, lint_sql, list_connections_command,
@@ -48,6 +48,7 @@ pub fn run() {
     .invoke_handler(tauri::generate_handler![
       connect_db,
       disconnect_db,
+      rename_connection,
       delete_connection,
       ping_connection,
       list_connections_command,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,12 +20,14 @@ import { CommandPalette } from "@/features/commands/components/CommandPalette";
 import { ShortcutSheet } from "@/features/commands/components/ShortcutSheet";
 import { SettingsDialog } from "@/features/commands/components/SettingsDialog";
 import { ConnectionDialog } from "@/features/connections/components/ConnectionDialog";
+import { RenameConnectionDialog } from "@/features/connections/components/RenameConnectionDialog";
 import { ConnectionsSidebarTree } from "@/features/connections/components/ConnectionsSidebarTree";
 import {
 	useActivateConnectionMutation,
 	useConnectionsQuery,
 	useConnectMutation,
 	useDeleteConnectionMutation,
+	useRenameConnectionMutation,
 } from "@/features/connections/queries";
 import { ModelWorkspace } from "@/features/model/components/ModelWorkspace";
 import { readOnboardingCompleted } from "@/features/onboarding/constants";
@@ -126,6 +128,7 @@ function VeloxApp() {
 	const [settingsOpen, setSettingsOpen] = useState(false)
 	const [commandPaletteOpen, setCommandPaletteOpen] = useState(false)
 	const [connectionDialogOpen, setConnectionDialogOpen] = useState(false);
+	const [renamingConnection, setRenamingConnection] = useState<ConnectionSummary | null>(null);
 	const [isSidebarCollapsed, setIsSidebarCollapsed] =
 		useState(readSidebarCollapsed);
 	const [sidebarWidth, setSidebarWidth] = useState(readSidebarWidth);
@@ -238,6 +241,12 @@ function VeloxApp() {
 				setTableSearch("");
 			}
 			notifySuccess("Connection deleted");
+		},
+	});
+
+	const renameConnectionMutation = useRenameConnectionMutation({
+		onError: (error) => {
+			notifyError(error, { category: "connection", force: true });
 		},
 	});
 
@@ -519,6 +528,30 @@ function VeloxApp() {
 		[connection?.engine],
 	);
 
+	const handleRenameConnectionRequest = useCallback(
+		(connectionTarget: ConnectionSummary) => {
+			setRenamingConnection(connectionTarget);
+		},
+		[],
+	);
+
+	const handleRenameConnectionConfirm = useCallback(
+		(connectionTarget: ConnectionSummary, newName: string) => {
+			renameConnectionMutation.mutate(
+				{ connectionId: connectionTarget.id, newName },
+				{
+					onSuccess: (updated) => {
+						if (connection?.id === updated.id) {
+							setConnection(updated);
+						}
+					},
+				},
+			);
+			setRenamingConnection(null);
+		},
+		[connection?.id, renameConnectionMutation],
+	);
+
 	const handleDisconnectConnectionRequest = useCallback(
 		(connectionTarget: ConnectionSummary) => {
 			const confirmed = window.confirm(
@@ -763,6 +796,7 @@ function VeloxApp() {
 									onTableQuickAction={handleTableQuickAction}
 									onRefreshConnection={handleRefreshConnection}
 									onRefreshTable={handleRefreshTable}
+									onRenameConnection={handleRenameConnectionRequest}
 									onDisconnectConnection={handleDisconnectConnectionRequest}
 									onRenameTable={handleRenameTableRequest}
 									onDeleteTable={handleDeleteTableRequest}
@@ -926,6 +960,13 @@ function VeloxApp() {
 					connectMutation.mutate(values);
 				}}
 				isPending={connectMutation.isPending}
+			/>
+
+			<RenameConnectionDialog
+				key={renamingConnection?.id ?? 'none'}
+				connection={renamingConnection}
+				onConfirm={handleRenameConnectionConfirm}
+				onCancel={() => setRenamingConnection(null)}
 			/>
 
 			<TablePropertiesDialog

--- a/src/data/repositories/TauriVeloxDbRepository.ts
+++ b/src/data/repositories/TauriVeloxDbRepository.ts
@@ -58,6 +58,12 @@ export class TauriVeloxDbRepository implements VeloxDbRepository {
     )
   }
 
+  async renameConnection(connectionId: string, newName: string): Promise<ConnectionSummary> {
+    return invokeCommand('rename_connection', () =>
+      invoke<ConnectionSummary>('rename_connection', { connectionId, newName }),
+    )
+  }
+
   async pingConnection(connectionId: string): Promise<void> {
     return invokeCommand('ping_connection', () =>
       invoke<void>('ping_connection', { connectionId }),

--- a/src/data/repositories/VeloxDbRepository.ts
+++ b/src/data/repositories/VeloxDbRepository.ts
@@ -28,6 +28,7 @@ export interface VeloxDbRepository {
   connectDb(input: ConnectionInput): Promise<ConnectionSummary>
   disconnectDb(connectionId: string): Promise<void>
   deleteConnection(connectionId: string): Promise<void>
+  renameConnection(connectionId: string, newName: string): Promise<ConnectionSummary>
   pingConnection(connectionId: string): Promise<void>
   listConnections(): Promise<ConnectionSummary[]>
   setActiveConnection(connectionId: string): Promise<ConnectionSummary>

--- a/src/features/connections/components/ConnectionsSidebarTree.tsx
+++ b/src/features/connections/components/ConnectionsSidebarTree.tsx
@@ -330,6 +330,7 @@ export function ConnectionsSidebarTree({
   onTableQuickAction,
   onRefreshConnection,
   onRefreshTable,
+  onRenameConnection,
   onDisconnectConnection,
   onRenameTable,
   onDeleteTable,
@@ -459,6 +460,7 @@ export function ConnectionsSidebarTree({
     () => [
       { id: 'copyConnectionString', label: 'Copy connection string', group: 'primary' },
       { id: 'refreshConnection', label: 'Refresh', group: 'secondary' },
+      { id: 'renameConnection', label: 'Rename', group: 'secondary' },
       { id: 'disconnectConnection', label: 'Delete', group: 'danger' },
     ],
     [],
@@ -513,6 +515,11 @@ export function ConnectionsSidebarTree({
             break
           case 'refreshConnection':
             void onRefreshConnection(connection)
+            break
+          case 'renameConnection':
+            if (onRenameConnection) {
+              void onRenameConnection(connection)
+            }
             break
           case 'disconnectConnection':
             if (onDisconnectConnection) {

--- a/src/features/connections/components/RenameConnectionDialog.tsx
+++ b/src/features/connections/components/RenameConnectionDialog.tsx
@@ -1,0 +1,74 @@
+import { useEffect, useRef, useState } from 'react'
+
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import type { ConnectionSummary } from '@/data/types'
+
+type RenameConnectionDialogProps = {
+  connection: ConnectionSummary | null
+  onConfirm: (connection: ConnectionSummary, newName: string) => void
+  onCancel: () => void
+}
+
+export function RenameConnectionDialog(
+  { connection, onConfirm, onCancel }: RenameConnectionDialogProps,
+) {
+  const [name, setName] = useState(connection?.name ?? '')
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    if (connection) {
+      inputRef.current?.select()
+    }
+  }, [connection])
+
+  const handleConfirm = () => {
+    if (!connection || !name.trim()) return
+    onConfirm(connection, name.trim())
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') handleConfirm()
+    if (e.key === 'Escape') onCancel()
+  }
+
+  return (
+    <Dialog open={!!connection} onOpenChange={(open) => { if (!open) onCancel() }}>
+      <DialogContent className="max-w-sm border border-border p-0">
+        <DialogHeader className="border-b border-border px-6 py-4">
+          <DialogTitle>Rename connection</DialogTitle>
+        </DialogHeader>
+
+        <div className="px-6 py-4">
+          <label htmlFor="connection-name" className="mb-2 block text-sm text-muted-foreground">
+            Connection name
+          </label>
+          <Input
+            id="connection-name"
+            ref={inputRef}
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            onKeyDown={handleKeyDown}
+            autoComplete="off"
+          />
+        </div>
+
+        <DialogFooter className="border-t border-border px-6 py-4">
+          <Button variant="outline" onClick={onCancel}>
+            Cancel
+          </Button>
+          <Button onClick={handleConfirm} disabled={!name.trim()}>
+            Rename
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/features/connections/queries.ts
+++ b/src/features/connections/queries.ts
@@ -152,6 +152,30 @@ export function useDisconnectMutation(options: UseDisconnectMutationOptions = {}
   })
 }
 
+type UseRenameConnectionMutationOptions = {
+  onSuccess?: (connection: ConnectionSummary) => void
+  onError?: (error: unknown) => void
+}
+
+export function useRenameConnectionMutation(options: UseRenameConnectionMutationOptions = {}) {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: ({ connectionId, newName }: { connectionId: string; newName: string }) =>
+      veloxDbRepository.renameConnection(connectionId, newName),
+    onSuccess: (updated) => {
+      queryClient.setQueryData<ConnectionSummary[]>(queryKeys.connections(), (current) => {
+        const existing = current ?? []
+        return existing.map((c) => (c.id === updated.id ? updated : c))
+      })
+      options.onSuccess?.(updated)
+    },
+    onError: (error) => {
+      options.onError?.(error)
+    },
+  })
+}
+
 type UseDeleteConnectionMutationOptions = {
   onSuccess?: (connectionId: string) => void
   onError?: (error: unknown, connectionId: string) => void


### PR DESCRIPTION
## Summary

- Added **Rename** option to the connection context menu in the sidebar
- Simple rename dialog opens with the current name pre-filled and text selected, matching the DBeaver UX pattern
- Rename is persisted to `connections.json` via a new Rust command `rename_connection`; the active connection pool and SSH tunnel are not affected
- The connections list and active connection state update optimistically in the UI via React Query

## Motivation
I though it will be useful to have a small function just to rename connection without updating other fields. Because I didnt want to delete and recreate connection just to rename it.
