### PR TITLE
chore: update build configuration and dependencies

### DIFF
--- a/build/index.html
+++ b/build/index.html
@@ -5,7 +5,9 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>veloxdb</title>
-    <script type="module" crossorigin src="/assets/index-BBFrdpjC.js"></script>
+    <script type="module" crossorigin src="/assets/index-_7h_Mlkc.js"></script>
+    <link rel="modulepreload" crossorigin href="/assets/editor.api2-Cv8II45O.js">
+    <link rel="stylesheet" crossorigin href="/assets/editor-Br_kD0ds.css">
     <link rel="stylesheet" crossorigin href="/assets/index-XBxMekhH.css">
   </head>
   <body>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "veloxdb",
-  "version": "0.1.0-8",
+  "version": "0.2.0",
   "identifier": "com.veloxdb.app",
   "build": {
     "frontendDist": "../build",
@@ -22,7 +22,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self'; connect-src 'self' https://openrouter.ai https://api.github.com http://localhost:3000 ws://localhost:3000; img-src 'self' data:; font-src 'self'; worker-src 'self' blob:"
+      "csp": "default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-eval'; connect-src 'self' https://openrouter.ai https://api.github.com http://localhost:3000 ws://localhost:3000; img-src 'self' data:; font-src 'self' data:; worker-src 'self' blob:"
     }
   },
   "bundle": {

--- a/src/lib/monaco-setup.ts
+++ b/src/lib/monaco-setup.ts
@@ -1,0 +1,35 @@
+import { loader } from '@monaco-editor/react'
+import * as monaco from 'monaco-editor'
+import editorWorker from 'monaco-editor/esm/vs/editor/editor.worker?worker'
+import cssWorker from 'monaco-editor/esm/vs/language/css/css.worker?worker'
+import htmlWorker from 'monaco-editor/esm/vs/language/html/html.worker?worker'
+import jsonWorker from 'monaco-editor/esm/vs/language/json/json.worker?worker'
+import tsWorker from 'monaco-editor/esm/vs/language/typescript/ts.worker?worker'
+
+/**
+ * Load Monaco from the bundled npm package instead of jsdelivr CDN. The app CSP
+ * blocks external script/connect sources, so the default loader never finishes.
+ */
+self.MonacoEnvironment = {
+  getWorker(_workerId, label) {
+    switch (label) {
+      case 'json':
+        return new jsonWorker()
+      case 'css':
+      case 'scss':
+      case 'less':
+        return new cssWorker()
+      case 'html':
+      case 'handlebars':
+      case 'razor':
+        return new htmlWorker()
+      case 'typescript':
+      case 'javascript':
+        return new tsWorker()
+      default:
+        return new editorWorker()
+    }
+  },
+}
+
+loader.config({ monaco })

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,6 +4,7 @@ import { QueryClientProvider } from '@tanstack/react-query'
 
 import './i18n'
 import './index.css'
+import '@/lib/monaco-setup'
 import App from './App.tsx'
 
 import { Toaster } from '@/components/ui/toaster'


### PR DESCRIPTION
This commit updates the build configuration by changing the version to 0.2.0 in tauri.conf.json, modifies the Content Security Policy to allow 'unsafe-eval', and adds new module preload links in index.html. Additionally, it imports the Monaco editor setup in main.tsx to enhance code editing capabilities.