### PR TITLE
fix: SQLite connect button and sidebar table listing

### DIFF
--- a/src-tauri/src/engines/sqlite.rs
+++ b/src-tauri/src/engines/sqlite.rs
@@ -1,8 +1,8 @@
 use tauri::AppHandle;
 
 use crate::db::{
-    build_sqlite_pool, get_or_create_sqlite_pool, quote_identifier,
-    require_safe_identifier, AppState,
+    build_sqlite_pool, get_or_create_sqlite_pool, is_safe_identifier,
+    quote_identifier, require_safe_identifier, AppState,
 };
 use crate::error::VeloxError;
 use crate::models::{ColumnInfo, ConnectionInput, DatabaseInfo, QueryResult, TableInfo};
@@ -76,7 +76,10 @@ impl DatabaseEngineOps for SqliteEngine {
         for row in rows {
             let name: String = sqlite_get_idx(&row, 0, "name", "get_tables")
                 .map_err(VeloxError::from)?;
-            require_safe_identifier(&name, "table name")?;
+            if !is_safe_identifier(&name) {
+                log::warn!("Skipping table with unsafe identifier: {:?}", name);
+                continue;
+            }
             tables.push(TableInfo {
                 schema: "main".to_string(),
                 preview_query: format!("select * from \"{}\" limit 100;", quote_identifier(&name)),

--- a/src/features/connections/components/ConnectionDialog.tsx
+++ b/src/features/connections/components/ConnectionDialog.tsx
@@ -72,7 +72,7 @@ const connectionSchema = z.object({
   name: z.string().min(2, 'Enter a connection name.'),
   engine: z.enum(['postgres', 'mysql', 'sqlite', 'mongo', 'duckdb', 'redis'] as const),
   host: z.string(),
-  port: z.coerce.number().int().min(1).max(65535),
+  port: z.coerce.number().int().min(0).max(65535),
   database: z.string(),
   filePath: z.string().optional(),
   user: z.string(),

--- a/src/features/connections/components/ConnectionsSidebarTree.tsx
+++ b/src/features/connections/components/ConnectionsSidebarTree.tsx
@@ -61,6 +61,11 @@ export function resolveExpandedDatabaseName(
       return dbList[0].name
     }
   }
+  if (connection.engine === 'sqlite' || connection.engine === 'duckdb') {
+    if (dbList.length > 0) {
+      return dbList[0].name
+    }
+  }
   return saved
 }
 


### PR DESCRIPTION
## Summary
Fixes three issues that prevented SQLite connections from working properly:

1. **Connect button unresponsive** — The zod form schema required `port >= 1` but SQLite/DuckDB set `port` to `0`. Validation failed silently because the port field is hidden for file-based engines. Fixed by allowing `port >= 0` in the base schema.

2. **Tables not showing in sidebar** — `resolveExpandedDatabaseName` returned the connection's file path (e.g. `/path/to/db.sqlite`) instead of the actual database name (`main`). Since `isDatabaseActive(main)` was always `false`, the tables panel never rendered. Added SQLite/DuckDB fallback to return the first database when no exact match exists (same pattern MySQL already uses).

3. **Entire table listing fails on a single non-standard table name** — `require_safe_identifier` used `?` in the `get_tables` loop, so any table with a hyphen, dot, or other non-ASCII-alphanumeric character caused the entire listing to fail. Changed to `is_safe_identifier` + `continue` to skip only the problematic table (matches DuckDB engine behavior).