### PR TITLE
chore: update fontsource package and adjust font imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@fontsource-variable/jetbrains-mono": "^5.2.8",
+    "@fontsource/jetbrains-mono": "^5.3.0",
     "@hookform/resolvers": "^5.2.2",
     "@monaco-editor/react": "^4.7.0",
     "@phosphor-icons/react": "^2.1.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,9 @@ importers:
 
   .:
     dependencies:
-      '@fontsource-variable/jetbrains-mono':
-        specifier: ^5.2.8
-        version: 5.2.8
+      '@fontsource/jetbrains-mono':
+        specifier: ^5.3.0
+        version: 5.3.0
       '@hookform/resolvers':
         specifier: ^5.2.2
         version: 5.2.2(react-hook-form@7.75.0(react@19.2.5))
@@ -382,8 +382,8 @@ packages:
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
 
-  '@fontsource-variable/jetbrains-mono@5.2.8':
-    resolution: {integrity: sha512-WBA9elru6Jdp5df2mES55wuOO0WIrn3kpXnI4+W2ek5u3ZgLS9XS4gmIlcQhiZOWEKl95meYdvK7xI+ETLCq/Q==}
+  '@fontsource/jetbrains-mono@5.3.0':
+    resolution: {integrity: sha512-fqDfB5I9f1p1TV486aUgB9t8zP84P0O1FtQR5Ol9vjwPy+S+EIGlVYm1cvj2W5shcZMTg2nZFdVMoH5wFu8a1A==}
 
   '@hono/node-server@1.19.14':
     resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
@@ -4183,7 +4183,7 @@ snapshots:
 
   '@floating-ui/utils@0.2.11': {}
 
-  '@fontsource-variable/jetbrains-mono@5.2.8': {}
+  '@fontsource/jetbrains-mono@5.3.0': {}
 
   '@hono/node-server@1.19.14(hono@4.12.16)':
     dependencies:

--- a/src/features/queries/components/ResultsGrid.tsx
+++ b/src/features/queries/components/ResultsGrid.tsx
@@ -1116,7 +1116,7 @@ export function ResultsGrid({
 											}`}
 											style={{
 												height: `${virtualRow.size}px`,
-												transform: `translateY(${virtualRow.start}px)`,
+												top: `${virtualRow.start}px`,
 												width: `${Math.max(totalGridWidthPx, 0)}px`,
 											}}
 										>

--- a/src/features/queries/components/SqlEditor.tsx
+++ b/src/features/queries/components/SqlEditor.tsx
@@ -6,6 +6,10 @@ import { useTranslation } from "react-i18next";
 
 import type { QueryEditorMetadata, SqlDiagnostic } from "@/data/types";
 
+const EDITOR_FONT_FAMILY = "JetBrains Mono";
+const EDITOR_FONT_SIZE = 13;
+const EDITOR_FONT_LOAD_TIMEOUT_MS = 2_000;
+
 type SqlEditorProps = {
 	value: string;
 	isDark: boolean;
@@ -201,8 +205,35 @@ export function SqlEditor({
 	const [editorInstance, setEditorInstance] =
 		useState<editor.IStandaloneCodeEditor | null>(null);
 	const [monacoInstance, setMonacoInstance] = useState<Monaco | null>(null);
+	const [isEditorFontReady, setIsEditorFontReady] = useState(
+		() => typeof document === "undefined" || !document.fonts,
+	);
 	const providerRef = useRef<IDisposable | null>(null);
 	const markersOwner = "veloxdb-sql-lint";
+
+	useEffect(() => {
+		if (typeof document === "undefined" || !document.fonts) return;
+
+		let isActive = true;
+		const finishLoading = () => {
+			if (!isActive) return;
+			window.clearTimeout(timeoutId);
+			setIsEditorFontReady(true);
+		};
+		const timeoutId = window.setTimeout(
+			finishLoading,
+			EDITOR_FONT_LOAD_TIMEOUT_MS,
+		);
+
+		void document.fonts
+			.load(`${EDITOR_FONT_SIZE}px "${EDITOR_FONT_FAMILY}"`)
+			.then(finishLoading, finishLoading);
+
+		return () => {
+			isActive = false;
+			window.clearTimeout(timeoutId);
+		};
+	}, []);
 
 	useEffect(() => {
 		if (!editorInstance || !monacoInstance) return;
@@ -280,6 +311,25 @@ export function SqlEditor({
 	};
 
 	useEffect(() => {
+		if (!editorInstance || !monacoInstance || !document.fonts) return;
+
+		let isActive = true;
+		const synchronizeFontMetrics = () => {
+			if (!isActive) return;
+			monacoInstance.editor.remeasureFonts();
+			editorInstance.layout();
+		};
+
+		document.fonts.addEventListener("loadingdone", synchronizeFontMetrics);
+		void document.fonts.ready.then(synchronizeFontMetrics);
+
+		return () => {
+			isActive = false;
+			document.fonts.removeEventListener("loadingdone", synchronizeFontMetrics);
+		};
+	}, [editorInstance, monacoInstance]);
+
+	useEffect(() => {
 		providerRef.current?.dispose();
 		if (!editorInstance || !monacoInstance) return;
 		providerRef.current = monacoInstance.languages.registerCompletionItemProvider("sql", {
@@ -302,6 +352,10 @@ export function SqlEditor({
 		return () => providerRef.current?.dispose();
 	}, [metadata, editorInstance, monacoInstance]);
 
+	if (!isEditorFontReady) {
+		return <div className="h-full w-full bg-background" aria-hidden />;
+	}
+
 	return (
 		<Editor
 			height="100%"
@@ -314,8 +368,8 @@ export function SqlEditor({
 			options={{
 				automaticLayout: true,
 				minimap: { enabled: false },
-				fontFamily: "JetBrains Mono Variable, monospace",
-				fontSize: 13,
+				fontFamily: `"${EDITOR_FONT_FAMILY}", monospace`,
+				fontSize: EDITOR_FONT_SIZE,
 				padding: { top: 16, bottom: 16 },
 				lineNumbersMinChars: 3,
 				scrollBeyondLastLine: false,

--- a/src/index.css
+++ b/src/index.css
@@ -1,7 +1,10 @@
 @import "tailwindcss";
 @import "tw-animate-css";
 @import "shadcn/tailwind.css";
-@import "@fontsource-variable/jetbrains-mono";
+@import "@fontsource/jetbrains-mono/400.css";
+@import "@fontsource/jetbrains-mono/500.css";
+@import "@fontsource/jetbrains-mono/600.css";
+@import "@fontsource/jetbrains-mono/700.css";
 
 @custom-variant dark (&:is(.dark *));
 
@@ -282,7 +285,7 @@
 }
 
 @theme inline {
-  --font-mono: "JetBrains Mono Variable", monospace;
+  --font-mono: "JetBrains Mono", monospace;
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);


### PR DESCRIPTION
- Replace @fontsource-variable/jetbrains-mono with @fontsource/jetbrains-mono version 5.3.0 in package.json and pnpm-lock.yaml.
- Update CSS imports to load specific font weights (400, 500, 600, 700) from the new fontsource package.
- Modify SqlEditor component to ensure proper font loading and synchronization with the editor's layout.